### PR TITLE
Rename `Database#all` to `Database#content`

### DIFF
--- a/lib/contentfs/database.rb
+++ b/lib/contentfs/database.rb
@@ -55,8 +55,8 @@ module ContentFS
       end
     end
 
-    def all
-      return to_enum(:all) unless block_given?
+    def content
+      return to_enum(:content) unless block_given?
 
       @children.each_value do |value|
         yield value

--- a/spec/features/iterating_spec.rb
+++ b/spec/features/iterating_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "iterating over content in a database" do
   }
 
   it "returns an enum containing direct content" do
-    iterator = database.all
+    iterator = database.content
 
     expect(iterator.count).to eq(2)
     expect(iterator.map(&:slug)).to eq([:foo, :bar])
@@ -20,7 +20,7 @@ RSpec.describe "iterating over content in a database" do
 
   it "iterates directly" do
     iterations = []
-    database.all do |content|
+    database.content do |content|
       iterations << content.slug
     end
 


### PR DESCRIPTION
Using `content` creates a more descriptive api than `all`.