### PR TITLE
Includes

### DIFF
--- a/spec/features/includes/support/includes/_has_include.md
+++ b/spec/features/includes/support/includes/_has_include.md
@@ -1,0 +1,1 @@
+<!-- @include simple -->

--- a/spec/features/includes/support/includes/_simple.md
+++ b/spec/features/includes/support/includes/_simple.md
@@ -1,0 +1,1 @@
+**this is a test**

--- a/spec/features/includes/support/includes/adjacent.md
+++ b/spec/features/includes/support/includes/adjacent.md
@@ -1,0 +1,1 @@
+<!-- @include simple -->

--- a/spec/features/includes/support/includes/child.md
+++ b/spec/features/includes/support/includes/child.md
@@ -1,0 +1,1 @@
+<!-- @include nested/child -->

--- a/spec/features/includes/support/includes/html_block.md
+++ b/spec/features/includes/support/includes/html_block.md
@@ -1,0 +1,3 @@
+<div>
+  <!-- @include simple -->
+</div>

--- a/spec/features/includes/support/includes/nested/_child.md
+++ b/spec/features/includes/support/includes/nested/_child.md
@@ -1,0 +1,1 @@
+**this is a child partial**

--- a/spec/features/includes/support/includes/nested/parent.md
+++ b/spec/features/includes/support/includes/nested/parent.md
@@ -1,0 +1,1 @@
+<!-- @include ../simple -->

--- a/spec/features/includes/support/includes/nested/top.md
+++ b/spec/features/includes/support/includes/nested/top.md
@@ -1,0 +1,1 @@
+<!-- @include simple -->

--- a/spec/features/includes/support/includes/with_include.md
+++ b/spec/features/includes/support/includes/with_include.md
@@ -1,0 +1,1 @@
+<!-- @include has_include -->

--- a/spec/features/includes_spec.rb
+++ b/spec/features/includes_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "contentfs"
+
+RSpec.describe "Including content" do
+  let(:database) {
+    ContentFS::Database.load(path)
+  }
+
+  let(:path) {
+    File.expand_path("../includes/support/includes", __FILE__)
+  }
+
+  it "includes adjacent content" do
+    expect(database.find(:adjacent).render).to eq_sans_whitespace("<p><strong>this is a test</strong></p>")
+  end
+
+  it "includes content into html blocks" do
+    expect(database.find(:html_block).render).to eq_sans_whitespace("<div><p><strong>this is a test</strong></p></div>")
+  end
+
+  it "includes content into other includes" do
+    expect(database.find(:with_include).render).to eq_sans_whitespace("<p><strong>this is a test</strong></p>")
+  end
+
+  it "includes content from child directories relative to self" do
+    expect(database.find(:child).render).to eq_sans_whitespace("<p><strong>this is a child partial</strong></p>")
+  end
+
+  it "includes content from parent directories relative to self" do
+    expect(database.find(:nested, :parent).render).to eq_sans_whitespace("<p><strong>this is a test</strong></p>")
+  end
+
+  it "includes content relative to the top-level database" do
+    expect(database.find(:nested, :top).render).to eq_sans_whitespace("<p><strong>this is a test</strong></p>")
+  end
+end


### PR DESCRIPTION
Adds support for includes, making it possible to do this:

```
<!-- @include foo -->
```

Includes must be prefixed with an underscore. ContentFS resolves includes with the following algorithm:

* Look for matching includes in the current directory.
* If the path is to a nested include, look in child directories.
* If the path is to a parent path, look in parent directories.
* Look for matching includes from the toplevel directory.