### PR TITLE
Replace redcarpet with cmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "redcarpet", require: false
+gem "commonmarker", require: false
 gem "rouge", require: false
 
 group :development do

--- a/lib/contentfs/content.rb
+++ b/lib/contentfs/content.rb
@@ -45,7 +45,7 @@ module ContentFS
     def render
       working_content = @content.dup
 
-      @content.scan(INCLUDE_REGEXP).each do |match|
+      @content.scan(INCLUDE_REGEXP) do |match|
         if (include = @database.find_include(match[0]))
           working_content.gsub!($~.to_s, include.render)
         end

--- a/lib/contentfs/renderers/markdown.rb
+++ b/lib/contentfs/renderers/markdown.rb
@@ -1,39 +1,14 @@
 # frozen_string_literal: true
 
-require "redcarpet"
+require "commonmarker"
 
 module ContentFS
   module Renderers
     # @api private
     class Markdown
       class << self
-        OPTIONS = {
-          autolink: true,
-          footnotes: true,
-          fenced_code_blocks: true,
-          tables: true
-        }.freeze
-
         def render(content)
-          renderer.render(content)
-        end
-
-        def options
-          OPTIONS
-        end
-
-        private def renderer
-          @_renderer ||= Redcarpet::Markdown.new(Renderer, options)
-        end
-      end
-
-      class Renderer < Redcarpet::Render::HTML
-        def block_quote(quote)
-          if (match = quote.match(/<p>\[(.*)\]/))
-            %(<blockquote class="#{match[1]}">#{quote.gsub("[#{match[1]}]", "")}</blockquote>)
-          else
-            super
-          end
+          CommonMarker.render_html(content, [:DEFAULT, :UNSAFE])
         end
       end
     end


### PR DESCRIPTION
Better performance and fewer bugs around html embedded into markdown content.