### PR TITLE
Provide a pattern for preprocessing content

### DIFF
--- a/lib/contentfs/content.rb
+++ b/lib/contentfs/content.rb
@@ -12,8 +12,8 @@ module ContentFS
   #
   class Content
     class << self
-      def load(path, database:, metadata: {}, namespace: [])
-        new(path: path, database: database, metadata: metadata, namespace: namespace)
+      def load(path, database:, metadata: {}, namespace: [], &block)
+        new(path: path, database: database, metadata: metadata, namespace: namespace, &block)
       end
     end
 
@@ -22,7 +22,7 @@ module ContentFS
 
     attr_reader :format, :prefix, :slug, :metadata, :namespace
 
-    def initialize(path:, database:, metadata: {}, namespace: [])
+    def initialize(path:, database:, metadata: {}, namespace: [], &block)
       path = Pathname.new(path)
       extname = path.extname
       name = path.basename(extname)
@@ -34,6 +34,7 @@ module ContentFS
       @database = database
 
       content = path.read
+      content = block.call(content) if block
       @metadata = metadata.merge(parse_metadata(content))
       @content = content.gsub(FRONT_MATTER_REGEXP, "")
     end

--- a/spec/features/preprocessing_spec.rb
+++ b/spec/features/preprocessing_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "contentfs"
+
+RSpec.describe "accessing content" do
+  let(:database) {
+    ContentFS::Database.load(path) do |content|
+      content.reverse
+    end
+  }
+
+  let(:path) {
+    File.expand_path("../content/support/content", __FILE__)
+  }
+
+  it "allows content to be preprocessed" do
+    expect(database.find(:simple).to_s).to eq_sans_whitespace("**elpmis**")
+  end
+end


### PR DESCRIPTION
This pattern makes it possible to preprocess content as it's loaded.

```ruby
ContentFS::Database.load(path) do |content|
  ...
end
```