### PR TITLE
Resolve includes after rendering

### DIFF
--- a/lib/contentfs/content.rb
+++ b/lib/contentfs/content.rb
@@ -44,19 +44,23 @@ module ContentFS
     end
 
     def render
-      working_content = @content.dup
+      if @format && (renderer = Renderers.resolve(@format))
+        resolve_includes(renderer.render(@content))
+      else
+        resolve_includes(to_s)
+      end
+    end
 
-      @content.scan(INCLUDE_REGEXP) do |match|
+    private def resolve_includes(content)
+      working_content = content.dup
+
+      content.scan(INCLUDE_REGEXP) do |match|
         if (include = @database.find_include(match[0]))
           working_content.gsub!($~.to_s, include.render)
         end
       end
 
-      if @format && (renderer = Renderers.resolve(@format))
-        renderer.render(working_content)
-      else
-        to_s
-      end
+      working_content
     end
 
     private def parse_metadata(content)

--- a/spec/features/includes/support/includes/_code.md
+++ b/spec/features/includes/support/includes/_code.md
@@ -1,0 +1,5 @@
+```ruby
+puts "hello"
+
+puts "goodbye"
+```

--- a/spec/features/includes/support/includes/code.md
+++ b/spec/features/includes/support/includes/code.md
@@ -1,0 +1,5 @@
+```ruby
+puts "hello"
+
+puts "goodbye"
+```

--- a/spec/features/includes/support/includes/with_code.md
+++ b/spec/features/includes/support/includes/with_code.md
@@ -1,0 +1,1 @@
+<!-- @include code -->

--- a/spec/features/includes_spec.rb
+++ b/spec/features/includes_spec.rb
@@ -34,4 +34,8 @@ RSpec.describe "Including content" do
   it "includes content relative to the top-level database" do
     expect(database.find(:nested, :top).render).to eq_sans_whitespace("<p><strong>this is a test</strong></p>")
   end
+
+  it "correctly includes content that is code" do
+    expect(database.find(:with_code).render).to eq_sans_whitespace(database.find(:code).render)
+  end
 end


### PR DESCRIPTION
This prevents formatting issues caused by double-rendering of markdown content.