### PR TITLE
Add support for typed blockquotes

### DIFF
--- a/contentfs.gemspec
+++ b/contentfs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@metabahn.com"
   spec.homepage = "https://github.com/metabahn/contentfs/"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.7"
 
   spec.license = "MIT"
 

--- a/lib/contentfs/renderers/markdown.rb
+++ b/lib/contentfs/renderers/markdown.rb
@@ -8,7 +8,37 @@ module ContentFS
     class Markdown
       class << self
         def render(content)
-          CommonMarker.render_html(content, [:DEFAULT, :UNSAFE])
+          renderer.render(CommonMarker.render_doc(content))
+        end
+
+        private def renderer
+          ContentFSRenderer.new(options: [:DEFAULT, :UNSAFE])
+        end
+      end
+
+      class ContentFSRenderer < CommonMarker::HtmlRenderer
+        def blockquote(node)
+          blockquote_type = if (match = node.to_plaintext.strip.match(/\[(.*)\]/))
+            match[1]
+          end
+
+          blockquote_class = if blockquote_type
+            " class=\"#{blockquote_type}\""
+          end
+
+          block do
+            container("<blockquote#{sourcepos(node)}#{blockquote_class}>\n", "</blockquote>") do
+              node.each.with_index do |child, index|
+                content = if blockquote_class && index == 0
+                  child.to_html.gsub("<p>[#{blockquote_type}] ", "<p>")
+                else
+                  child
+                end
+
+                out(content)
+              end
+            end
+          end
         end
       end
     end

--- a/lib/contentfs/renderers/markdown/code.rb
+++ b/lib/contentfs/renderers/markdown/code.rb
@@ -19,13 +19,13 @@ module ContentFS
           end
         end
 
-        class SyntaxRenderer < CommonMarker::HtmlRenderer
+        class SyntaxRenderer < ContentFSRenderer
           def code_block(node)
             block do
               language = node.fence_info.split(/\s+/)[0]
               out("<div class=\"highlight\"><pre class=\"highlight #{language}\"><code>")
               out(syntax_highlight(node.string_content, language))
-              out('</code></pre></div>')
+              out("</code></pre></div>")
             end
           end
 

--- a/spec/features/blockquotes/support/content/typed.md
+++ b/spec/features/blockquotes/support/content/typed.md
@@ -1,0 +1,1 @@
+> [testing] This is a test.

--- a/spec/features/blockquotes/support/content/untyped.md
+++ b/spec/features/blockquotes/support/content/untyped.md
@@ -1,0 +1,1 @@
+> This is a test.

--- a/spec/features/blockquotes_spec.rb
+++ b/spec/features/blockquotes_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "contentfs"
+
+RSpec.describe "defining blockquotes with a type" do
+  let(:database) {
+    ContentFS::Database.load(path)
+  }
+
+  let(:path) {
+    File.expand_path("../blockquotes/support/content", __FILE__)
+  }
+
+  it "adds a class to typed blockquotes" do
+    expect(database.find(:typed).render).to eq_sans_whitespace(
+      <<~CONTENT
+        <blockquote class="testing">
+          <p>
+            This is a test.
+          </p>
+        </blockquote>
+      CONTENT
+    )
+  end
+
+  it "does not add a class to untyped blockquotes" do
+    expect(database.find(:untyped).render).to eq_sans_whitespace(
+      <<~CONTENT
+        <blockquote>
+          <p>
+            This is a test.
+          </p>
+        </blockquote>
+      CONTENT
+    )
+  end
+end


### PR DESCRIPTION
Allows blockquotes to be defined with a type:

```markdown
> [some-type] ...
```

```html
<blockquote class="some-type">
  <p>
    ...
  </p>
</blockquote>
```